### PR TITLE
galaxy.yml: Update dep, doc, repo, homepage and issues

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -41,19 +41,20 @@ tags: []
 # collection label 'namespace.name'. The value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
-dependencies: {}
+dependencies:
+    "ansible.netcommon": "*"
 
 # The URL of the originating SCM repository
-repository: http://example.com/repository
+repository: https://github.com/aruba/hpeanfc-ansible-collection
 
 # The URL to any online docs
-documentation: http://docs.example.com
+documentation: https://developer.arubanetworks.com/aruba-fabric-composer/docs/workflows
 
 # The URL to the homepage of the collection/project
-homepage: http://example.com
+homepage: https://developer.arubanetworks.com/aruba-fabric-composer/docs/getting-started-with-ansible-and-afc
 
 # The URL to the collection issue tracker
-issues: http://example.com/issue/tracker
+issues: https://github.com/aruba/hpeanfc-ansible-collection/issue
 
 # A list of file glob-like patterns used to filter any files or directories that should not be included in the build
 # artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This


### PR DESCRIPTION
Update link to github repo and dev arubanetwork AFC page

also update dependencies (-> ansible.netcommmon)
(based on change on aoscx collection

fix link when go on galaxy AFC collections (redirect to example.com when click on link)